### PR TITLE
Update click dependency to >=7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
-click = "^7.0"
+click = ">=7.0"
 requests = "^2.23.0"
 python-magic = "^0.4.15"
 termcolor = "^1.1.0"


### PR DESCRIPTION
Fedora and others have upgraded to at least version 8, and upstream is
8.1.6 at this time.

In order to package this into Fedora (rawhide), it would be beneficial
to bump this dependency.
