### PR TITLE
steck: fix domain

### DIFF
--- a/steck.py
+++ b/steck.py
@@ -20,7 +20,7 @@ configuration_path = (
 )
 
 configuration = {
-    "base": "https://bpaste.net/",
+    "base": "https://bpa.st/",
     "confirm": True,
     "magic": True,
     "ignore": True,


### PR DESCRIPTION
Due to infrastructural changes a POST directly to bpaste.net is now a 405 as it redirects to bpa.st and doesn't accept the POST directly.

This closes #34.